### PR TITLE
[PATCH 1/2] sun7i-a20-bananapi-r1.dts: initialize ahci 5v power

### DIFF
--- a/arch/arm/dts/sun7i-a20-bananapi-r1.dts
+++ b/arch/arm/dts/sun7i-a20-bananapi-r1.dts
@@ -90,6 +90,7 @@
 };
 
 &ahci {
+	target-supply = <&reg_ahci_5v>;
 	status = "okay";
 };
 
@@ -181,6 +182,10 @@
 		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
 		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
 	};
+};
+
+&reg_ahci_5v {
+	status = "okay";
 };
 
 &reg_usb1_vbus {


### PR DESCRIPTION
This addresses problems with SATA device power; most likely including the hard drive issues with power work-arounds for USB power.  I had severe issues running a rootfs on SSD with the default device tree files, but no issues whatsoever with this patch.  Tested over several days compiling kernels and toolchains on the device while powered over microusb with no more problems.  Second pull request coming for part 2 kernel patch.
